### PR TITLE
Resolve the Issue of Double Encoding in Query Parameters

### DIFF
--- a/src/main/java/com/unir/gateway/decorator/GetRequestDecorator.java
+++ b/src/main/java/com/unir/gateway/decorator/GetRequestDecorator.java
@@ -12,6 +12,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Flux;
 
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 
 /**
@@ -50,8 +52,11 @@ public class GetRequestDecorator extends ServerHttpRequestDecorator {
     @Override
     @NonNull
     public URI getURI() {
+        String url = gatewayRequest.getExchange().getAttributes().get(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR).toString();
+        String decodedUrl = URLDecoder.decode(url, StandardCharsets.UTF_8);
+
         return UriComponentsBuilder
-                .fromUri((URI) gatewayRequest.getExchange().getAttributes().get(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR))
+                .fromUriString(decodedUrl)
                 .queryParams(gatewayRequest.getQueryParams())
                 .build()
                 .toUri();

--- a/src/main/java/com/unir/gateway/decorator/GetRequestDecorator.java
+++ b/src/main/java/com/unir/gateway/decorator/GetRequestDecorator.java
@@ -12,8 +12,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Flux;
 
 import java.net.URI;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 
 
 /**
@@ -52,11 +50,8 @@ public class GetRequestDecorator extends ServerHttpRequestDecorator {
     @Override
     @NonNull
     public URI getURI() {
-        String url = gatewayRequest.getExchange().getAttributes().get(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR).toString();
-        String decodedUrl = URLDecoder.decode(url, StandardCharsets.UTF_8);
-
         return UriComponentsBuilder
-                .fromUriString(decodedUrl)
+                .fromUri((URI) gatewayRequest.getExchange().getAttributes().get(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR))
                 .queryParams(gatewayRequest.getQueryParams())
                 .build()
                 .toUri();

--- a/src/main/java/com/unir/gateway/decorator/RequestDecoratorFactory.java
+++ b/src/main/java/com/unir/gateway/decorator/RequestDecoratorFactory.java
@@ -30,7 +30,7 @@ public class RequestDecoratorFactory {
      * @throws IllegalArgumentException if the HTTP method of the request is neither GET nor POST
      */
         public ServerHttpRequestDecorator getDecorator(GatewayRequest request) {
-            return switch (request.getTargetMethod().name()) {
+            return switch (request.getTargetMethod().name().toUpperCase()) {
                 case "GET" -> new GetRequestDecorator(request);
                 case "POST" -> new PostRequestDecorator(request, objectMapper);
                 default -> throw new IllegalArgumentException("Invalid http method");


### PR DESCRIPTION
fix(RequestDecoratorFactory.java) Transform targetMethod to uppercase.

fix(GetRequestDecorator.java) URI is encoded when getting it from Exchange, and it gets encoded again when passing this URL through the UriComponentsBuilder resulting in query params like '%2520'. Here '%20' is the empty space character encoded but when it gets encoded again we end up with the encoded character of the percentage symbol '%25'. This could be added to the other request decorators too.